### PR TITLE
Updates for bitrise build in monorepo .gitlab-ci

### DIFF
--- a/template-monorepo/.gitlab-ci.yml
+++ b/template-monorepo/.gitlab-ci.yml
@@ -89,8 +89,8 @@ deploy_mobile:
           export TIER="develop"
       fi
   script:
-    - curl https://app.bitrise.io/app/$BITRISE_APP_ID/build/start.json --data "{\"hook_info\":{\"type\":\"bitrise\",\"build_trigger_token\":\"$BITRISE_BUILD_TRIGGER_TOKEN\"},\"build_params\":{\"workflow_id\":\"ios\",\"branch\":\"$CI_COMMIT_REF_NAME\",\"commit_hash\":\"$CI_COMMIT_SHA\",\"environments\":[{\"mapped_to\":\"TIER\",\"value\":\"$TIER\",\"is_expand\":true}]},\"triggered_by\":\"GitLab CI\"}"
-    - curl https://app.bitrise.io/app/$BITRISE_APP_ID/build/start.json --data "{\"hook_info\":{\"type\":\"bitrise\",\"build_trigger_token\":\"$BITRISE_BUILD_TRIGGER_TOKEN\"},\"build_params\":{\"workflow_id\":\"android\",\"branch\":\"$CI_COMMIT_REF_NAME\",\"commit_hash\":\"$CI_COMMIT_SHA\",\"environments\":[{\"mapped_to\":\"TIER\",\"value\":\"$TIER\",\"is_expand\":true}]},\"triggered_by\":\"GitLab CI\"}"
+    - curl https://app.bitrise.io/app/$BITRISE_APP_ID/build/start.json --fail-with-body --data "{\"hook_info\":{\"type\":\"bitrise\",\"build_trigger_token\":\"$BITRISE_BUILD_TRIGGER_TOKEN\"},\"build_params\":{\"workflow_id\":\"ios\",\"branch\":\"$CI_COMMIT_REF_NAME\",\"commit_hash\":\"$CI_COMMIT_SHA\",\"environments\":[{\"mapped_to\":\"TIER\",\"value\":\"$TIER\",\"is_expand\":true}]},\"triggered_by\":\"GitLab CI\"}"
+    - curl https://app.bitrise.io/app/$BITRISE_APP_ID/build/start.json --fail-with-body --data "{\"hook_info\":{\"type\":\"bitrise\",\"build_trigger_token\":\"$BITRISE_BUILD_TRIGGER_TOKEN\"},\"build_params\":{\"workflow_id\":\"android\",\"branch\":\"$CI_COMMIT_REF_NAME\",\"commit_hash\":\"$CI_COMMIT_SHA\",\"environments\":[{\"mapped_to\":\"TIER\",\"value\":\"$TIER\",\"is_expand\":true}]},\"triggered_by\":\"GitLab CI\"}"
   only:
     refs:
       - production

--- a/template-monorepo/.gitlab-ci.yml
+++ b/template-monorepo/.gitlab-ci.yml
@@ -78,7 +78,7 @@ deploy_web:
 
 deploy_mobile:
   stage: deploy
-  image: curlimages/curl:7.74.0
+  image: curlimages/curl:7.76.0
   before_script:
     - |
       if [ "${CI_COMMIT_REF_NAME}" = "production" ]; then

--- a/template-monorepo/.gitlab-ci.yml
+++ b/template-monorepo/.gitlab-ci.yml
@@ -89,8 +89,8 @@ deploy_mobile:
           export TIER="develop"
       fi
   script:
-    - curl https://app.bitrise.io/app/$BITRISE_APP_ID/build/start.json --fail-with-body --data "{\"hook_info\":{\"type\":\"bitrise\",\"build_trigger_token\":\"$BITRISE_BUILD_TRIGGER_TOKEN\"},\"build_params\":{\"workflow_id\":\"ios\",\"branch\":\"$CI_COMMIT_REF_NAME\",\"commit_hash\":\"$CI_COMMIT_SHA\",\"environments\":[{\"mapped_to\":\"TIER\",\"value\":\"$TIER\",\"is_expand\":true}]},\"triggered_by\":\"GitLab CI\"}"
-    - curl https://app.bitrise.io/app/$BITRISE_APP_ID/build/start.json --fail-with-body --data "{\"hook_info\":{\"type\":\"bitrise\",\"build_trigger_token\":\"$BITRISE_BUILD_TRIGGER_TOKEN\"},\"build_params\":{\"workflow_id\":\"android\",\"branch\":\"$CI_COMMIT_REF_NAME\",\"commit_hash\":\"$CI_COMMIT_SHA\",\"environments\":[{\"mapped_to\":\"TIER\",\"value\":\"$TIER\",\"is_expand\":true}]},\"triggered_by\":\"GitLab CI\"}"
+    - curl https://app.bitrise.io/app/$BITRISE_APP_ID/build/start.json --fail-with-body --data "{\"hook_info\":{\"type\":\"bitrise\",\"build_trigger_token\":\"$BITRISE_BUILD_TRIGGER_TOKEN\"},\"build_params\":{\"workflow_id\":\"ios\",\"branch\":\"$CI_COMMIT_REF_NAME\",\"commit_hash\":\"$CI_COMMIT_SHA\",\"commit_message\":\"$CI_COMMIT_TITLE\",\"environments\":[{\"mapped_to\":\"TIER\",\"value\":\"$TIER\",\"is_expand\":true}]},\"triggered_by\":\"GitLab CI\"}"
+    - curl https://app.bitrise.io/app/$BITRISE_APP_ID/build/start.json --fail-with-body --data "{\"hook_info\":{\"type\":\"bitrise\",\"build_trigger_token\":\"$BITRISE_BUILD_TRIGGER_TOKEN\"},\"build_params\":{\"workflow_id\":\"android\",\"branch\":\"$CI_COMMIT_REF_NAME\",\"commit_hash\":\"$CI_COMMIT_SHA\",\"commit_message\":\"$CI_COMMIT_TITLE\",\"environments\":[{\"mapped_to\":\"TIER\",\"value\":\"$TIER\",\"is_expand\":true}]},\"triggered_by\":\"GitLab CI\"}"
   only:
     refs:
       - production


### PR DESCRIPTION
- Fail deploy_mobile step if bitrise request is failed using curl `--fail-with-body` flag [https://curl.se/docs/manpage.html#--fail-with-body](https://curl.se/docs/manpage.html#--fail-with-body)
- Use commit_message field to provide commit title to Bitrise